### PR TITLE
add sharing

### DIFF
--- a/experimental/try-builtin/index.html
+++ b/experimental/try-builtin/index.html
@@ -7,11 +7,19 @@
 		<script src="wasm_exec.js"></script>
 
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lz-string@1.4.4/libs/lz-string.min.js"></script>
         <script src="../../jquery-linedtextarea.js"></script>
         <script src="../../playground.js"></script>
+        <script src="../../sharing.js"></script>
 
 		<script>
             $(document).ready(function() {
+                initSharing({
+                    codeEl: '#code',
+                    shareEl: '#share',
+                    shareURLEl: '#shareURL',
+                });
+
                 $('#code').linedtextarea();
                 $('#code').attr('wrap', 'off');
 
@@ -150,6 +158,8 @@
 			<div id="controls">
 				<input type="button" value="Loading..." id="run" disabled />
                 <input type="button" value="Format" id="fmt" style="display:none;" disabled>
+				<input type="button" value="Share" id="share">
+				<input type="text" id="shareURL" style="display:none;">
 			</div>
             <a style="float:right;padding:15px;font-family:sans-serif;" href="https://github.com/ccbrown/wasm-go-playground" target="_blank">github.com/ccbrown/wasm-go-playground</a>
 		</div>

--- a/index.html
+++ b/index.html
@@ -7,11 +7,19 @@
 		<script src="wasm_exec.js"></script>
 
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lz-string@1.4.4/libs/lz-string.min.js"></script>
         <script src="jquery-linedtextarea.js"></script>
         <script src="playground.js"></script>
+        <script src="sharing.js"></script>
 
 		<script>
             $(document).ready(function() {
+                initSharing({
+                    codeEl: '#code',
+                    shareEl: '#share',
+                    shareURLEl: '#shareURL',
+                });
+
                 $('#code').linedtextarea();
                 $('#code').attr('wrap', 'off');
 
@@ -150,6 +158,8 @@
 			<div id="controls">
 				<input type="button" value="Loading..." id="run" disabled />
                 <input type="button" value="Format" id="fmt" style="display:none;" disabled>
+				<input type="button" value="Share" id="share">
+				<input type="text" id="shareURL" style="display:none;">
 			</div>
             <a style="float:right;padding:15px;font-family:sans-serif;" href="https://github.com/ccbrown/wasm-go-playground" target="_blank">github.com/ccbrown/wasm-go-playground</a>
 		</div>

--- a/sharing.js
+++ b/sharing.js
@@ -1,0 +1,37 @@
+function initSharing(opts) {
+    var code = $(opts.codeEl);
+    var share = $(opts.shareEl);
+    var shareURL = $(opts.shareURLEl);
+
+    var encodeHash = () => {
+        var encoded = LZString.compressToBase64(code.val());
+        window.location.hash = encoded;
+    };
+
+    var decodeHash = () => {
+        if (window.location.hash && window.location.hash.length > 1) {
+            var decoded = LZString.decompressFromBase64(window.location.hash.substr(1));
+            if (decoded) {
+                code.val(decoded);
+            } else {
+                window.location.hash = '';
+            }
+        }
+    };
+
+
+    code[0].addEventListener('input', () => {
+        window.location.hash = '';
+        shareURL.hide();
+    });
+
+    decodeHash();
+    window.addEventListener('hashchange', () => {
+        decodeHash();
+    });
+
+    share.click(() => {
+        encodeHash();
+        shareURL.show().val(window.location).focus().select();
+    });
+}

--- a/sharing.js
+++ b/sharing.js
@@ -19,7 +19,6 @@ function initSharing(opts) {
         }
     };
 
-
     code[0].addEventListener('input', () => {
         window.location.hash = '';
         shareURL.hide();


### PR DESCRIPTION
Adds sharing. In the spirit of doing things in the browser, sharing is also serverless. The code just gets encoded to the URL hash.

https://ccbrown.github.io/wasm-go-playground/experimental/try-builtin/#A4Qwxg1iDmCmAEBbEBLAdgKAwFwJ7AQFEAnY+AZ22PWgwDMBXNMeACiNIEp4TiB7Yq26VqaaPADe8YrGwNiaClRrtuAXyyNm8ONgDKDAEYArWGGxC2ImgBp4sUgO4SMASAD07+FVzTYwABtwGng0FAD4AHcUbAALHlJWACJdAxMzbHtHYiTONxk5BXgkyIEAgBMku15k1KNTcyz+HLyNeiYWchBcAAlYAIC+SwdmyTdgUWwAtGS+gb47JPgAam9iXFY69PMhblWkgEJc/Nl5RTCAjDatFmR0SxdXFDom+AAuAF4KbrnBoQBuV4HL4XMauVygMJgdhcNwaDRAA===